### PR TITLE
updated rgb to hsl conversion, handle white/grey/black

### DIFF
--- a/Sources/Rainbow/Color.swift
+++ b/Sources/Rainbow/Color.swift
@@ -319,27 +319,36 @@ extension Color {
     public var hsla: (hue: Int, saturation: Int, lightness: Int, alpha: Double) {
         let max = Swift.max(r, g, b)
         let min = Swift.min(r, g, b)
-
-        let d = max - min
-
-        let l = (max + min) / 2
-        var h = 0.0
+        
+        // calc lightness
+        let l = (max + min) / 2.0
+        
+        // calc saturation
         var s = 0.0
 
-        if r == max {
-            h = (g - b) / d
+        if (max == min) {
+            s = 0.0
+        } else if (l < 0.5) {
+            s = (max - min) / (max + min)
+        } else if (l >= 0.5) {
+            s = (max - min) / (2.0 - max - min)
+        }
+        
+        // calc hue
+        var h = 0.0
+        // if saturation is 0, hue is undefined, set to 0
+        if s == 0.0 {
+            h = 0.0
+        } else if r == max {
+            h = (g - b) / (max - min)
         } else if g == max {
-            h = 2 + (b - r) / d
+            h = 2 + (b - r) / (max - min)
         } else if b == max {
-            h = 4 + (r - g) / d
+            h = 4 + (r - g) / (max - min)
         }
 
         h = Swift.min(h * 60, 360)
         if h < 0 { h += 360 }
-
-        if d != 0 {
-            s = l <= 0.5 ? d / (max + min) : d / (2 - max - min)
-        }
 
         return (hue: Int(h), saturation: Int(s * 100), lightness: Int(l * 100), alpha: a)
     }

--- a/Tests/RainbowTests/RainbowTests.swift
+++ b/Tests/RainbowTests/RainbowTests.swift
@@ -64,6 +64,14 @@ final class RainbowTests: XCTestCase {
         XCTAssert(color == other!)
     }
 
+    func testConversionEdgeCases() {
+        let rgbInit = Color(red: 255, green: 255, blue: 255) // edge case: what hue does white/grey/black have? --> define as 0
+        let hsla = rgbInit.hsla // this shouldn't fail
+        XCTAssert(hsla.hue == 0)
+        XCTAssert(hsla.saturation == 0)
+        XCTAssert(hsla.lightness == 100)
+    }
+
     func testHexColor() {
         let color1 = Color(hex: "abcf")
         let color2 = Color(hex: "#AABBCC")
@@ -94,6 +102,7 @@ final class RainbowTests: XCTestCase {
     static var allTests = [
         ("testRGBAColor", testRGBAColor),
         ("testHSLAColor", testHSLAColor),
-        ("testHSVAColor", testHSVAColor)
+        ("testHSVAColor", testHSVAColor),
+        ("testConversionEdgeCases", testConversionEdgeCases)
     ]
 }


### PR DESCRIPTION
When accessing .hsla on a color with 0 saturation (white/grey/black) there was an error in the final Int(hue) cast, because the hue calculation involved a division by 0.